### PR TITLE
Add ops log capabilities to drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ info/keys.py
 info/mail_info.py
 info/__pycache__
 email_notify.py
-state.log
+log.*
 state.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
-info/
+info/keys.py
+info/mail_info.py
+info/__pycache__
 email_notify.py
 state.log
 state.log*

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 
 ### Locator configuration
 
-Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```info/keys.py```.  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
+Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```thermopi/info/keys.py```.  A template is provided in ```therompi/info/example_keys.py```.  Here is arecommended course of aciton:
 
 ```bash
 cd thermopi/info

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 
 ### Locator configuration
 
-Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```thermopi/info/keys.py```.  A template is provided in ```therompi/info/example_keys.py```.  Here is a recommended course of aciton:
+Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```thermopi/info/keys.py```.  A template is provided in ```therompi/info/example_keys.py```.  Here is a recommended course of action:
 
 ```bash
 cd thermopi/info

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install screen so you can run it continuously in the background.
 sudo apt-get install screen
 ```
 
-Allow execution of thermo script (for running thermo.py on a detched screen).
+Allow execution of thermo script (for running thermo.py on a detached screen).
 
 ```bash
 sudo chmod +x thermopi/thermo.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# thermopi v2.1
+# thermopi v3.0
 Smart thermostat with Raspberry Pi
 
 I got annoyed with my ordinary thermostat because I wanted different temperature targets at different times of day.  After determining that replacing it with a relay module governed by a Raspberry Pi would be simple, I set about making my own smart thermostat.  The possibilities for new features are endless and I'm definitely open to suggestions.  Now my wall is ugly where my naked Raspberry Pi Zero W hangs idly by its power cord near the relay, supporting the thermometer's breadboard by jumper wire.  So the next big step will be to build some housing for it.  Other feature ideas are hidden throughout the code in comments.
@@ -102,7 +102,7 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 
 ### Locator configuration
 
-Before enabling the locator, you must first specify your Life360 username, password, and the lat/lon of your house (in decimal degrees).  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
+Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees).  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
 
 ```bash
 cd thermopi/info

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 
 ### Locator configuration
 
-Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees).  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
+Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```info/keys.py```.  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
 
 ```bash
 cd thermopi/info

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 
 ### Locator configuration
 
-Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```thermopi/info/keys.py```.  A template is provided in ```therompi/info/example_keys.py```.  Here is arecommended course of aciton:
+Before enabling the locator, you must first specify your Life360 username, password, and the (lat,lon) of your house (in decimal degrees) in the file ```thermopi/info/keys.py```.  A template is provided in ```therompi/info/example_keys.py```.  Here is a recommended course of aciton:
 
 ```bash
 cd thermopi/info

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ I got annoyed with my ordinary thermostat because I wanted different temperature
 
 ## Physical configuration
 
-- Use as Raspberry Pi Zero W configured to your home WiFi network.
+- Raspberry Pi Zero W configured to home WiFi network.
   - Enable SSH (then change user/password for security).
 
-- Use a single relay module connecting furnace signal wire in the N/O position.
+- Single relay module connecting furnace signal wire in the N/O position.
   - Relay module input signal wire is currently configured to GPIO18 on RPi.
   - https://www.amazon.com/HiLetgo-Channel-Module-Isolation-Support/dp/B00LW2H5GC/
   
-- Use a DHT22 temperature/humidity sensor.
+- DHT22 temperature/humidity sensor.
   - Signal wire currently configured to GPIO4 on RPi.
   - https://www.adafruit.com/product/385
   

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ sudo cp example_keys.py keys.py
 
 Use an editor to configure the variables in ```keys.py```.
 
-Now, back in ```thermopi/namelist.yaml```, we can configure out locator settings.
+Now, back in ```thermopi/namelist.yaml```, we can configure the locator settings.
 
-- ```locator```: Set to True for on and False for off.
+- ```locator```: Set to *True* for on and *False* for off.
 - ```radius```: The radial distance (in km) from your house within which normal operation will take place.
 -  ```away_T```: The minimum target temperature for when you are outside of the radius.

--- a/README.md
+++ b/README.md
@@ -79,15 +79,15 @@ sudo screen -list
 sudo screen -r
 ```
 
-You can confirm that your thermostat is running by checking the state.log.  The most recent entries will reflect the time of the last scan.  If state.log does not exist, then the script has not been executed properly.
+You can confirm that your thermostat is running by checking the state log.  The most recent entries will reflect the time and state of the last cycle.  If it does not exist, then the script has not been executed properly.
 
 ```bash
-tail state.log
+tail logs/log.state
 ```
 
 ## Configuring Operation
 
-All options for operation of the furnace can be configured by altering the ```namelist.yaml``` file.  The namelist is read in every cycle and can be adjusted during operation.  The first three options within the namelist are the phase configuration options.  There should be an equal number of each (up to 1440) which determines the total number of phases.
+All options for operation of the furnace can be configured by altering the ```thermopi/namelist.yaml``` file.  The namelist is read in every cycle and can be adjusted during operation.  The first three options within the namelist are the phase configuration options.  There should be an equal number of each (up to 1440) which determines the total number of phases.
 
 - ```phase_hr```: Specifies the starting hour of a new phase (must use 24-hour format).
 - ```phase_min```: Specifies the starting minute of respective phase.
@@ -98,7 +98,21 @@ The next two options are the tolerances.  Generally you want to undershoot your 
 - ```up_tol```: The amount above the target temperature to shutoff the furnace.
 - ```dn_tol```: The amount below the target temperature to trigger the furnace.
 
-The final option is frequency (```freq```).  It is the frequency in Hz of sampling.  For example, a freq of 0.1 samples every 10 seconds.
+```freq``` is the frequency in Hz of sampling.  For example, a freq of 0.1 samples every 10 seconds.
 
 ### Locator configuration
-All in due time, my pretties.
+
+Before enabling the locator, you must first specify your Life360 username, password, and the lat/lon of your house (in decimal degrees).  A template is provided in ```info/example_keys.py```.  Here is arecommended course of aciton:
+
+```bash
+cd thermopi/info
+sudo cp example_keys.py keys.py
+```
+
+Use an editor to configure the variables in ```keys.py```.
+
+Now, back in ```thermopi/namelist.yaml```, we can configure out locator settings.
+
+- ```locator```: Set to True for on and False for off.
+- ```radius```: The radial distance (in km) from your house within which normal operation will take place.
+-  ```away_T```: The minimum target temperature for when you are outside of the radius.

--- a/info/example_keys.py
+++ b/info/example_keys.py
@@ -1,0 +1,3 @@
+username = "life360_username"
+password = "life360_password"
+home     = (39.729, -121.842)   # you home location

--- a/thermo.py
+++ b/thermo.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import RPi.GPIO     as GPIO
 import Adafruit_DHT as ad
@@ -19,6 +20,9 @@ log_stat = "F"
 temps = [0] * 4
 
 try:
+    # Redirect system output to logs
+    sys.stdout = open('logs/log.stdout', 'w')
+    sys.stderr = open('logs/log.stderr', 'w')
     while True:
 
         # Retrieve humidity, temperature, and local time
@@ -52,6 +56,12 @@ try:
         time.sleep(1/freq)
 
 finally:
+    # Clear GPIO config
     GPIO.output(18, False)
     GPIO.cleanup( )
+    # Close and redirect output
+    sys.stdout.close()
+    sys.stdout = sys.__stdout__
+    sys.stderr.close()
+    sys.stderr = sys.__stderr__
     wl.write_ops(lt, bulletin="thermopi terminated")

--- a/thermo.py
+++ b/thermo.py
@@ -25,9 +25,6 @@ log_stat = "F"
 # Empty list for averaging temperatures
 temps = [0] * 4
 
-# Write header to log
-wl.write_state(" Time, T(F), H(%), Status")
-
 try:
     while True:
 
@@ -54,9 +51,7 @@ try:
                     wl.write_ops( stat, lt, temp )
 
             # Write state and times to log
-            ## Need to add dtg to log
-            wl.write_state(" %02d:%02d:%02d, %0.1f, %02d, %s" \
-                        % ( lt[3], lt[4], lt[5], temp, hum, log_stat ))
+            wl.write_state( temp, hum, log_stat, lt )
 
             # Add new temp, delete oldest even if perturbation magnitude is high
             temps = update( temp, temps )

--- a/thermo.py
+++ b/thermo.py
@@ -48,7 +48,7 @@ try:
                 if stat is not None:
                     GPIO.output(18, stat)
                     log_stat = "T" if stat else "F"
-                    wl.write_ops( stat, lt, temp )
+                    wl.write_ops( lt, stat, temp )
 
             # Write state and times to log
             wl.write_state( temp, hum, log_stat, lt )
@@ -61,5 +61,4 @@ try:
 finally:
     GPIO.output(18, False)
     GPIO.cleanup( )
-    #wl.write_ops(
-    wl.write_err("thermopi terminated", lt)
+    wl.write_ops(lt, bulletin="thermopi terminated")

--- a/thermo.py
+++ b/thermo.py
@@ -60,8 +60,8 @@ finally:
     GPIO.output(18, False)
     GPIO.cleanup( )
     # Close and redirect output
+    wl.write_ops(lt, bulletin="thermopi terminated")
     sys.stdout.close()
     sys.stdout = sys.__stdout__
     sys.stderr.close()
     sys.stderr = sys.__stderr__
-    wl.write_ops(lt, bulletin="thermopi terminated")

--- a/thermo.py
+++ b/thermo.py
@@ -1,4 +1,3 @@
-import os
 import time
 import RPi.GPIO     as GPIO
 import Adafruit_DHT as ad
@@ -6,12 +5,6 @@ import thermo_query as tq
 import write_log    as wl
 from   tools        import *
 from   read_nl      import read_nl
-
-# Remove previous error log
-try:
-    os.remove("log.err")
-except:
-    pass
 
 # Set up GPIO board
 GPIO.setwarnings(False)

--- a/thermo_query.py
+++ b/thermo_query.py
@@ -1,6 +1,5 @@
 from read_nl import read_nl
 from locator import get_min_dist
-from write_log import write_err
 
 def query( lt, T, outpt ):
     # Input: local time, temperature, current relay status
@@ -50,7 +49,8 @@ def query( lt, T, outpt ):
             if get_min_dist() > nml_opts['radius']:
                 TT = nml_opts['away_T']
         except:
-            write_err("Unable to retrieve location data!", lt)
+            print( "%02d%02d%02d_%02d:%02d:%02d - Unable to retrieve location data!" %
+                   (lt[0], lt[1], lt[2], lt[3], lt[4], lt[5]) )
 
     # If output is True/False, check threshold
     if outpt:

--- a/thermo_query.py
+++ b/thermo_query.py
@@ -1,8 +1,11 @@
 from read_nl import read_nl
 from locator import get_min_dist
+from write_log import write_err
 
-def query( hr, mn, T, outpt ):
-    # Input: hour, minute, temperature, current relay status
+def query( lt, T, outpt ):
+    # Input: local time, temperature, current relay status
+    hr = lt[3]
+    mn = lt[4]
 
     # Reads namelist every time, allowing user to
     #  change settings without halting operation
@@ -47,8 +50,7 @@ def query( hr, mn, T, outpt ):
             if get_min_dist() > nml_opts['radius']:
                 TT = nml_opts['away_T']
         except:
-            # Should write to error log
-            print("Unable to retrieve location info!") 
+            write_err("Unable to retrieve location data!", lt)
 
     # If output is True/False, check threshold
     if outpt:

--- a/write_log.py
+++ b/write_log.py
@@ -1,8 +1,15 @@
 import os
 
-# Remove previous error log on startup
+# Make logs directory
 try:
-    os.remove("log.err")
+    os.mkdir('logs')
+except:
+    pass
+
+# Remove previous system logs on startup
+try:
+    os.remove("logs/log.stdout")
+    os.remove("logs/log.stderr")
 except:
     pass
 
@@ -12,15 +19,16 @@ def dtg_htg( lt ):
     return dtg, htg
 
 def write_state( temp, hum, stat, lt ):
+    # Write to continuous state log
     dtg, htg = dtg_htg( lt )
     entry = "%s, %s, %0.1f, %02d, %s\n" % (dtg, htg, temp, hum, stat)
-    with open("log.state", "a") as f:
+    with open("logs/log.state", "a") as f:
         f.write( entry )
 
-def write_err( entry, lt ):
-    dtg, htg = dtg_htg( lt )
-    with open("log.err", "a") as f:
-        f.write( "%s, %s - %s\n" % (dtg, htg, entry) )
+#def write_err( entry, lt ):
+#    dtg, htg = dtg_htg( lt )
+#    with open("log.err", "a") as f:
+#        f.write( "%s, %s - %s\n" % (dtg, htg, entry) )
 
 def write_ops( lt, status=None, T=None, bulletin=None ):
     dtg, htg = dtg_htg( lt )
@@ -28,9 +36,5 @@ def write_ops( lt, status=None, T=None, bulletin=None ):
     entry = entry + "room temp %0.1f" % T
     if bulletin is not None:
         entry = bulletin
-    try:
-        with open("ops/log.ops_%s" % dtg, "a") as f:
-            f.write( "%s - %s\n" % (htg, entry) )
-    except:
-        os.mkdir("ops")
-        write_ops(stat, lt, temp, bulletin)
+    with open("logs/log.ops_%s" % dtg, "a") as f:
+        f.write( "%s - %s\n" % (htg, entry) )

--- a/write_log.py
+++ b/write_log.py
@@ -1,5 +1,11 @@
 import os
 
+# Remove previous error log on startup
+try:
+    os.remove("log.err")
+except:
+    pass
+
 def dtg_htg( lt ):
     dtg = "%04d%02d%02d" % ( lt[0], lt[1], lt[2] )      # date time group
     htg = "%02d:%02d:%02d" % ( lt[3], lt[4], lt[5] )    # hour time group

--- a/write_log.py
+++ b/write_log.py
@@ -1,3 +1,5 @@
+import os
+
 def dtg_htg( lt ):
     dtg = "%04d%02d%02d" % ( lt[0], lt[1], lt[2] )      # date time group
     htg = "%02d:%02d:%02d" % ( lt[3], lt[4], lt[5] )    # hour time group
@@ -14,8 +16,15 @@ def write_err( entry, lt ):
     with open("log.err", "a") as f:
         f.write( "%s, %s - %s\n" % (dtg, htg, entry) )
 
-def write_ops( stat, lt, temp ):
+def write_ops( lt, status=None, T=None, bulletin=None ):
     dtg, htg = dtg_htg( lt )
-    entry = "Furnace on" if stat else "Furnace off"     # change of status entry
-    with open("log.ops_%s" % dtg, "a") as f:
-        f.write( "%s - %s, room temp %0.1f\n" % (htg, entry, temp) )
+    entry = "Furnace on, " if status else "Furnace off, "     # change of status entry
+    entry = entry + "room temp %01f" % T
+    if bulletin is not None:
+        entry = bulletin
+    try:
+        with open("ops/log.ops_%s" % dtg, "a") as f
+            f.write( "%s - %s\n" % (htg, entry) )
+    except:
+        os.mkdir("ops")
+        write_ops(stat, lt, temp, bulletin)

--- a/write_log.py
+++ b/write_log.py
@@ -25,11 +25,11 @@ def write_err( entry, lt ):
 def write_ops( lt, status=None, T=None, bulletin=None ):
     dtg, htg = dtg_htg( lt )
     entry = "Furnace on, " if status else "Furnace off, "     # change of status entry
-    entry = entry + "room temp %01f" % T
+    entry = entry + "room temp %0.1f" % T
     if bulletin is not None:
         entry = bulletin
     try:
-        with open("ops/log.ops_%s" % dtg, "a") as f
+        with open("ops/log.ops_%s" % dtg, "a") as f:
             f.write( "%s - %s\n" % (htg, entry) )
     except:
         os.mkdir("ops")

--- a/write_log.py
+++ b/write_log.py
@@ -1,16 +1,21 @@
-def write_state( string ):
-    with open("state.log", "a") as f:
-        f.write( string + "\n" )
+def dtg_htg( lt ):
+    dtg = "%04d%02d%02d" % ( lt[0], lt[1], lt[2] )      # date time group
+    htg = "%02d:%02d:%02d" % ( lt[3], lt[4], lt[5] )    # hour time group
+    return dtg, htg
+
+def write_state( temp, hum, stat, lt ):
+    dtg, htg = dtg_htg( lt )
+    entry = "%s, %s, %0.1f, %02d, %s\n" % (dtg, htg, temp, hum, stat)
+    with open("log.state", "a") as f:
+        f.write( entry )
 
 def write_err( entry, lt ):
-    dtg = "%04d%02d%02d" % ( lt[0], lt[1], lt[2] )      # date time group
-    htg = "%02d:%02d:%02d" % ( lt[3], lt[4], lt[5] )    # hour time group
+    dtg, htg = dtg_htg( lt )
     with open("log.err", "a") as f:
-        f.write( "%s_%s - %s\n" % (dtg, htg, entry) )
+        f.write( "%s, %s - %s\n" % (dtg, htg, entry) )
 
 def write_ops( stat, lt, temp ):
-    dtg = "%04d%02d%02d" % ( lt[0], lt[1], lt[2] )      # date time group
-    htg = "%02d:%02d:%02d" % ( lt[3], lt[4], lt[5] )    # hour time group
+    dtg, htg = dtg_htg( lt )
     entry = "Furnace on" if stat else "Furnace off"     # change of status entry
     with open("log.ops_%s" % dtg, "a") as f:
         f.write( "%s - %s, room temp %s\n" % (htg, entry, temp) )

--- a/write_log.py
+++ b/write_log.py
@@ -18,4 +18,4 @@ def write_ops( stat, lt, temp ):
     dtg, htg = dtg_htg( lt )
     entry = "Furnace on" if stat else "Furnace off"     # change of status entry
     with open("log.ops_%s" % dtg, "a") as f:
-        f.write( "%s - %s, room temp %s\n" % (htg, entry, temp) )
+        f.write( "%s - %s, room temp %0.1f\n" % (htg, entry, temp) )


### PR DESCRIPTION
Still needs:
* state.log (log.state) overhaul
* uniform log formatting
* increased ops log capabilities (not just stat entry but string entries, too)
* it would be cool if ops log included arrivals and exits from locator